### PR TITLE
the mail octet like ".15.11.1/products.php?id=9"

### DIFF
--- a/lib/Protocol/Pop3.php
+++ b/lib/Protocol/Pop3.php
@@ -639,7 +639,7 @@ class Pop3 extends AbstractProtocol
      */
     private function _isTerminationOctet($resp)
     {
-        if (preg_match("/\.\s/",$resp) && strpos(rtrim($resp, self::CRLF), self::TERMINATION_OCTET) === 0 ) {
+        if (strpos(rtrim($resp, self::CRLF), self::TERMINATION_OCTET) === 0 && strlen(rtrim($resp, self::CRLF)) == 1  ) {
             return true;
         }
 

--- a/lib/Protocol/Pop3.php
+++ b/lib/Protocol/Pop3.php
@@ -639,7 +639,7 @@ class Pop3 extends AbstractProtocol
      */
     private function _isTerminationOctet($resp)
     {
-        if (strpos(rtrim($resp, self::CRLF), self::TERMINATION_OCTET) === 0 ) {
+        if (preg_match("/\.\s/",$resp) && strpos(rtrim($resp, self::CRLF), self::TERMINATION_OCTET) === 0 ) {
             return true;
         }
 


### PR DESCRIPTION
the mime protol:
http://www.ietf.org/rfc/rfc1939.txt

 Responses to certain commands are multi-line.  In these cases, which
   are clearly indicated below, after sending the first line of the
   response and a CRLF, any additional lines are sent, each terminated
   by a CRLF pair.  When all lines of the response have been sent, a
   final line is sent, consisting of a termination octet (decimal code
   046, ".") and a CRLF pair.

if the mail octet like ".15.11.1/products.php?id=9",maybe the line throw a exception.
